### PR TITLE
Fix Repo URL

### DIFF
--- a/GraphicsConfig.json
+++ b/GraphicsConfig.json
@@ -6,7 +6,7 @@
   "ApplicableVersion": "any",
   "Description": "Allows you to save/load/share graphical setting presets (based on your System Configuration menu) at any time, including when triggered by events like entering a battle, cutscene, or gpose.",
   "Punchline": "Save/load/share graphical setting presets at any time!",
-  "RepoUrl": "hhttps://github.com/Aida-Enna/GraphicsConfig",
+  "RepoUrl": "https://github.com/Aida-Enna/GraphicsConfig",
   "Tags": [
     "graphics",
     "config",


### PR DESCRIPTION
The Repo URL had an extra H making the link nonfunctional in the Plugin Browser.